### PR TITLE
#25 bugfix

### DIFF
--- a/log4j.properties
+++ b/log4j.properties
@@ -1,9 +1,11 @@
-# Set root category priority to INFO and its only appender to CONSOLE.
-log4j.rootCategory=WARN, CONSOLE
+# 
 
-# Comment the above and uncomment the following if a user has issues 
-# log4j.rootCategory=INFO, CONSOLE, LOGFILE
-#log4j.rootCategory=INFO, CONSOLE, LOGFILE, GUI
+# NORMAL MODEL: only shows WARN logs on console
+log4j.rootCategory=WARN, CONSOLE
+# DEBUG MODE: shows all logging on console and logfile (comment the above line and uncomment the following log4j line)
+# log file is stored in the folder where bamqc executable file exists.
+#log4j.rootCategory=DEBUG, CONSOLE, LOGFILE
+
 
 # Set the enterprise logger category to FATAL and its only appender to CONSOLE.
 #log4j.logger.org.apache.axis.enterprise=FATAL, CONSOLE
@@ -18,7 +20,7 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%-5p %c %M:%L - %m%n
 log4j.appender.LOGFILE=org.apache.log4j.FileAppender
 log4j.appender.LOGFILE.File=bamqc.log
 log4j.appender.LOGFILE.Append=false
-log4j.appender.LOGFILE.Threshold=WARN
+log4j.appender.LOGFILE.Threshold=DEBUG
 log4j.appender.LOGFILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.LOGFILE.layout.ConversionPattern=%-4r [%t] %-5p %c %M:%L %x - %m%n
 


### PR DESCRIPTION
If plotBinsPerChromosome is smaller than chromosomes.length, then plotBinsPerChromosome is set to 1. Before this commit, this was set to 0, causing a division to zero in the assignment of binRatio (=infinity),
which led to an exception when the array replicateCounts was accessed.